### PR TITLE
update slf4j to 2; drop unused jjschema dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.rcsb</groupId>
     <artifactId>rcsb-mojave-tools</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
 
     <properties>
 

--- a/src/main/java/org/rcsb/mojave/tools/utils/NameUtils.java
+++ b/src/main/java/org/rcsb/mojave/tools/utils/NameUtils.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -12,7 +13,7 @@ import java.util.Collection;
  * @author Yana Valasatava
  * @since 1.0.0
  */
-public class NameUtils {
+public final class NameUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(NameUtils.class);
 
@@ -20,38 +21,34 @@ public class NameUtils {
 
     // Java name can contain only latin characters (english uppercase or lowercase characters),
     // numbers, the dollar sign ( $ ), and the underscore character ( _ ).
-    private static final String JAVA_ILLEGAL_NAME_REGEX = ".*[^0-9a-zA-Z_$].*";
 
     // Java name is a valid identifier ONLY if beginning with a letter, the dollar sign "$",
     // or the underscore character "_".
-    private static final String JAVA_NAME_ILLEGAL_FIRST_CHARACTER_REGEX = "^[^a-zA-Z_$].*$";
+    private static final Pattern ILLEGAL_FIRST_CHAR_REGEX = Pattern.compile("^[^a-zA-Z_$].*$");
 
     // Java name can contain only latin characters (english uppercase or lowercase characters),
     // numbers, the dollar sign ( $ ), and the underscore character ( _ ).
-    private static final String JAVA_NAME_ILLEGAL_CHARACTER_SET_REGEX = "[^0-9a-zA-Z_$]";
+    private static final Pattern ILLEGAL_CHAR_REGEX = Pattern.compile("[^0-9a-zA-Z_$]");
 
     /**
      * Utilities to ensure that generated Java field names are consistent with
      * the specification for Java language. For more information refer to
      * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/variables.html">Java
-     * rules for naming variables</>.
+     * rules for naming variables</a>.
      *
      * @param name the name to be converted to legal Java name.
      *
      * @return name where characters, that are not allowed by Java language, are replaced with '_'.
      */
     public static String makeNameBeLegalJavaName(String name) {
-
-        if (name.matches(JAVA_ILLEGAL_NAME_REGEX) || name.matches(JAVA_NAME_ILLEGAL_FIRST_CHARACTER_REGEX)) {
-            String modifiedName = name.replaceAll(JAVA_NAME_ILLEGAL_CHARACTER_SET_REGEX, "_");
-            if(modifiedName.matches(JAVA_NAME_ILLEGAL_FIRST_CHARACTER_REGEX))
-                modifiedName ="_"+modifiedName;
-            logger.warn("Field name \"{}\" violates naming rules for Java language. This name will be changed to \"{}\".",
-                    name, modifiedName);
-            return modifiedName;
+        String modified = ILLEGAL_CHAR_REGEX.matcher(name).replaceAll("_");
+        if (ILLEGAL_FIRST_CHAR_REGEX.matcher(name).matches()) {
+            modified = "_" + modified;
         }
-
-        return name;
+        if (!modified.equals(name.replace(' ', '_'))) {
+            logger.debug("Renamed field '{}' → '{}'.", name, modified);
+        }
+        return modified;
     }
 
     /**
@@ -64,16 +61,11 @@ public class NameUtils {
      * @return case insensitive representation for a name
      */
     public static String makeUnique(String name, Collection<String> existingNames) {
-        boolean found = false;
         for (String existingName : existingNames) {
             if (name.equalsIgnoreCase(existingName)) {
-                found = true;
-                break;
+                return name;
             }
         }
-        if (found) {
-            name = makeUnique(name + "_", existingNames);
-        }
-        return name;
+        return makeUnique(name + "_", existingNames);
     }
 }


### PR DESCRIPTION
Due to the way mojave-tools is used as a plugin, its legacy slf4j gets picked up.

I also dropped `jjschema` because it appears unused; I wasn't sure about this one.