### PR TITLE
Resolve paths to either file system or java-packaged resource

### DIFF
--- a/src/main/java/org/rcsb/mojave/tools/jsonschema/SchemaLoader.java
+++ b/src/main/java/org/rcsb/mojave/tools/jsonschema/SchemaLoader.java
@@ -92,7 +92,13 @@ public class SchemaLoader {
 
         if (uri.getScheme() == null ) {
 
-            InputStream is = SchemaLoader.class.getResourceAsStream(uri.getSchemeSpecificPart());
+            InputStream is;
+            String schemeSpecificPart = uri.getSchemeSpecificPart();
+            if (Paths.get(schemeSpecificPart).toFile().exists()) {
+                is = new FileInputStream(Paths.get(schemeSpecificPart).toFile());
+            } else {
+                is = SchemaLoader.class.getResourceAsStream(schemeSpecificPart);
+            }
             if (is == null)
                 throw new IOException("Cannot read schema from " + uri.getSchemeSpecificPart() + ". Resource doesn't exist.");
             return readSchema(is);

--- a/src/main/java/org/rcsb/mojave/tools/jsonschema/SchemaLoader.java
+++ b/src/main/java/org/rcsb/mojave/tools/jsonschema/SchemaLoader.java
@@ -94,13 +94,14 @@ public class SchemaLoader {
 
             InputStream is;
             String schemeSpecificPart = uri.getSchemeSpecificPart();
-            if (Paths.get(schemeSpecificPart).toFile().exists()) {
-                is = new FileInputStream(Paths.get(schemeSpecificPart).toFile());
+            File probeFile = new File(schemeSpecificPart);
+            if (probeFile.exists() && probeFile.isFile()) {
+                is = new FileInputStream(probeFile);
             } else {
                 is = SchemaLoader.class.getResourceAsStream(schemeSpecificPart);
             }
             if (is == null)
-                throw new IOException("Cannot read schema from " + uri.getSchemeSpecificPart() + ". Resource doesn't exist.");
+                throw new IOException("Cannot read schema from " + uri.getSchemeSpecificPart() + ". The path doesn't exist as a file in file system nor as a java-packaged resource.");
             return readSchema(is);
 
         } else if (uri.getScheme().equals(JAR_SCHEME)) {

--- a/src/main/java/org/rcsb/mojave/tools/jsonschema/SchemaLoader.java
+++ b/src/main/java/org/rcsb/mojave/tools/jsonschema/SchemaLoader.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.rcsb.mojave.tools.core.GenerateCombinedJsonSchema;
 import org.rcsb.mojave.tools.utils.CommonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URI;
@@ -23,6 +25,8 @@ import java.nio.file.Paths;
  * @since 1.0.0
  */
 public class SchemaLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(SchemaLoader.class);
 
     private final ObjectMapper objectMapper;
 
@@ -95,13 +99,17 @@ public class SchemaLoader {
             InputStream is;
             String schemeSpecificPart = uri.getSchemeSpecificPart();
             File probeFile = new File(schemeSpecificPart);
+            URL resourceUrl = SchemaLoader.class.getResource(schemeSpecificPart);
             if (probeFile.exists() && probeFile.isFile()) {
                 is = new FileInputStream(probeFile);
+                if (resourceUrl != null)
+                    logger.warn("Schema uri '{}' can be resolved both to a file system path and to a java-packaged resource. Will use the file system one.", uri.getSchemeSpecificPart());
+            } else if (resourceUrl != null) {
+                is = resourceUrl.openStream();
             } else {
-                is = SchemaLoader.class.getResourceAsStream(schemeSpecificPart);
-            }
-            if (is == null)
                 throw new IOException("Cannot read schema from " + uri.getSchemeSpecificPart() + ". The path doesn't exist as a file in file system nor as a java-packaged resource.");
+            }
+
             return readSchema(is);
 
         } else if (uri.getScheme().equals(JAR_SCHEME)) {

--- a/src/main/java/org/rcsb/mojave/tools/jsonschema/utils/JsonSchemaNodeUtils.java
+++ b/src/main/java/org/rcsb/mojave/tools/jsonschema/utils/JsonSchemaNodeUtils.java
@@ -90,7 +90,7 @@ public class JsonSchemaNodeUtils {
         if (baseURI == null || refValue.startsWith("#") || SchemaLoader.hasScheme(refValue))
             refPath = refValue;
         else
-            refPath = Paths.get(baseURI, refValue).toFile().getPath();
+            refPath = Paths.get(baseURI, refValue).toFile().getCanonicalPath();
         return new JsonReference(refPath);
     }
 

--- a/src/main/java/org/rcsb/mojave/tools/jsonschema/utils/JsonSchemaNodeUtils.java
+++ b/src/main/java/org/rcsb/mojave/tools/jsonschema/utils/JsonSchemaNodeUtils.java
@@ -90,7 +90,7 @@ public class JsonSchemaNodeUtils {
         if (baseURI == null || refValue.startsWith("#") || SchemaLoader.hasScheme(refValue))
             refPath = refValue;
         else
-            refPath = Paths.get(baseURI, refValue).toFile().getCanonicalPath();
+            refPath = Paths.get(baseURI, refValue).toFile().getPath();
         return new JsonReference(refPath);
     }
 

--- a/src/test/java/org/rcsb/mojave/tools/jsonschema/resolver/TestSchemaRefResolver.java
+++ b/src/test/java/org/rcsb/mojave/tools/jsonschema/resolver/TestSchemaRefResolver.java
@@ -169,4 +169,6 @@ public class TestSchemaRefResolver {
         assertEquals(MetaSchemaType.STRING, schema.get(MetaSchemaProperty.PROPERTIES)
                 .get("field2").get(MetaSchemaProperty.TYPE).asText());
     }
+
+    // TODO test case for relative path
 }

--- a/src/test/java/org/rcsb/mojave/tools/jsonschema/resolver/TestSchemaRefResolver.java
+++ b/src/test/java/org/rcsb/mojave/tools/jsonschema/resolver/TestSchemaRefResolver.java
@@ -9,8 +9,18 @@ import org.rcsb.mojave.tools.jsonschema.SchemaRefResolver;
 import org.rcsb.mojave.tools.jsonschema.constants.MetaSchemaProperty;
 import org.rcsb.mojave.tools.jsonschema.constants.MetaSchemaType;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -105,6 +115,51 @@ public class TestSchemaRefResolver {
         URL source = TestSchemaRefResolver.class
                 .getResource("/schema/resolving/json-schema-chase-refs.json");
         JsonNode schema = loader.readSchema(source);
+
+        SchemaRefResolver resolver = new SchemaRefResolver(schema, loader);
+        resolver.resolveInline();
+
+        assertEquals(MetaSchemaType.STRING, schema.get(MetaSchemaProperty.PROPERTIES)
+                .get("field1").get(MetaSchemaProperty.TYPE).asText());
+        assertEquals(MetaSchemaType.STRING, schema.get(MetaSchemaProperty.PROPERTIES)
+                .get("field2").get(MetaSchemaProperty.TYPE).asText());
+    }
+
+    private void setUpMockSchemainFileSystem() throws IOException {
+        Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+        InputStream isRootSchema = TestSchemaRefResolver.class.getResourceAsStream("/schema/resolving/json-schema-chase-refs.json");
+        InputStream isDir1Schema = TestSchemaRefResolver.class.getResourceAsStream("/schema/resolving/dir1/json-schema-fragment-1.json");
+        InputStream isDir2f2Schema = TestSchemaRefResolver.class.getResourceAsStream("/schema/resolving/dir2/json-schema-fragment-2.json");
+        InputStream isDir2f3Schema = TestSchemaRefResolver.class.getResourceAsStream("/schema/resolving/dir2/json-schema-fragment-3.json");
+        writeIsToFileModifyingId(isRootSchema, tmpDir + "/json-schema-chase-refs.json", new File(tmpDir.toFile(), "json-schema-chase-refs.json"));
+        File dir1 = new File(tmpDir.toFile(), "dir1");
+        dir1.mkdir();
+        writeIsToFileModifyingId(isDir1Schema, tmpDir + "/dir1/json-schema-fragment-1.json", new File(dir1, "json-schema-fragment-1.json"));
+        File dir2 = new File(tmpDir.toFile(), "dir2");
+        dir2.mkdir();
+        writeIsToFileModifyingId(isDir2f2Schema, null, new File(dir2, "json-schema-fragment-2.json"));
+        writeIsToFileModifyingId(isDir2f3Schema, null, new File(dir2, "json-schema-fragment-3.json"));
+        // TODO cleanup
+    }
+
+    private void writeIsToFileModifyingId(InputStream is, String id, File outFile) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+             PrintWriter out = new PrintWriter(outFile)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("  \"$id\":")) {
+                    line = "  \"$id\": \"" + id + "\",";
+                }
+                out.println(line);
+            }
+        }
+    }
+
+    @Test
+    public void shouldChaseReferencesWhenSchemaFromFileSystem() throws IOException {
+        setUpMockSchemainFileSystem();
+        Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+        JsonNode schema = loader.readSchema(new File(tmpDir.toFile(), "json-schema-chase-refs.json"));
 
         SchemaRefResolver resolver = new SchemaRefResolver(schema, loader);
         resolver.resolveInline();


### PR DESCRIPTION
With a new test.

This is needed to build schemas by reading directly from file system, instead of reading from files in jar or another java-packaged resource. Worst case is that both paths exists and the file system one is used (with a warning)