### PR TITLE
New CLI option that control whether enum definitions are suppressed

### DIFF
--- a/src/main/java/org/rcsb/mojave/tools/core/GenerateAutoJsonSchema.java
+++ b/src/main/java/org/rcsb/mojave/tools/core/GenerateAutoJsonSchema.java
@@ -11,15 +11,14 @@ import org.rcsb.mojave.tools.utils.CommonUtils;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import static java.util.Arrays.asList;
 
 /**
  * This tool generates JSON schemas used to automatically produce corresponding Java classes. It annotates
  * all schemas in a given "core schemas" folder with Java type names.
- *
+ * <p>
  * Created on 9/17/18.
  *
  * @author Yana Valasatava
@@ -40,12 +39,24 @@ public class GenerateAutoJsonSchema {
         String coreSchemasLocation = cmd.valueOf("-i").get(0);
         String autoSchemasLocation = cmd.valueOf("-o").get(0);
         String targetPackage = cmd.valueOf("-t").get(0);
+
+        String supressEnumsParam = cmd.valueOf("-se").get(0);
+        boolean supressEnums = supressEnumsParam.isEmpty()
+                || Boolean.parseBoolean(supressEnumsParam);
+
         CommonUtils.ensurePathToFolderExist(new File(autoSchemasLocation));
 
-        EnumTransformer javaEnumVisitor = new EnumTransformer();
+        List<Visitor> visitors = new ArrayList<>();
+        // Adds annotations to configure the Java type names
         JavaTypeAnnotator javaTypeNameVisitor = new JavaTypeAnnotator();
         javaTypeNameVisitor.setTargetPackage(targetPackage);
-        List<Visitor> visitors = asList(javaEnumVisitor, javaTypeNameVisitor);
+        visitors.add(javaTypeNameVisitor);
+        if (supressEnums) {
+            // Removes enum annotation from schema nodes transforming the definition
+            // from controlled vocabulary to a free text string
+            EnumTransformer javaEnumVisitor = new EnumTransformer();
+            visitors.add(javaEnumVisitor);
+        }
 
         SchemaLoader loader = new SchemaLoader();
 

--- a/src/main/java/org/rcsb/mojave/tools/core/GenerateAutoJsonSchema.java
+++ b/src/main/java/org/rcsb/mojave/tools/core/GenerateAutoJsonSchema.java
@@ -40,9 +40,9 @@ public class GenerateAutoJsonSchema {
         String autoSchemasLocation = cmd.valueOf("-o").get(0);
         String targetPackage = cmd.valueOf("-t").get(0);
 
-        String supressEnumsParam = cmd.valueOf("-se").get(0);
-        boolean supressEnums = supressEnumsParam.isEmpty()
-                || Boolean.parseBoolean(supressEnumsParam);
+        String suppressEnumsParam = cmd.valueOf("-se").get(0);
+        boolean suppressEnums = suppressEnumsParam.isEmpty()
+                || Boolean.parseBoolean(suppressEnumsParam);
 
         CommonUtils.ensurePathToFolderExist(new File(autoSchemasLocation));
 
@@ -51,7 +51,7 @@ public class GenerateAutoJsonSchema {
         JavaTypeAnnotator javaTypeNameVisitor = new JavaTypeAnnotator();
         javaTypeNameVisitor.setTargetPackage(targetPackage);
         visitors.add(javaTypeNameVisitor);
-        if (supressEnums) {
+        if (suppressEnums) {
             // Removes enum annotation from schema nodes transforming the definition
             // from controlled vocabulary to a free text string
             EnumTransformer javaEnumVisitor = new EnumTransformer();

--- a/src/main/java/org/rcsb/mojave/tools/core/GenerateAutoJsonSchema.java
+++ b/src/main/java/org/rcsb/mojave/tools/core/GenerateAutoJsonSchema.java
@@ -40,9 +40,8 @@ public class GenerateAutoJsonSchema {
         String autoSchemasLocation = cmd.valueOf("-o").get(0);
         String targetPackage = cmd.valueOf("-t").get(0);
 
-        String suppressEnumsParam = cmd.valueOf("-se").get(0);
-        boolean suppressEnums = suppressEnumsParam.isEmpty()
-                || Boolean.parseBoolean(suppressEnumsParam);
+        boolean suppressEnums = cmd.valueOf("-se").isEmpty()
+                || Boolean.parseBoolean(cmd.valueOf("-se").get(0));
 
         CommonUtils.ensurePathToFolderExist(new File(autoSchemasLocation));
 


### PR DESCRIPTION
This PR introduces a new CLI option that control whether enum definitions are suppressed during the transformations of schema files that will be used in POJO generation process