### PR TITLE
Upgrading jaxb so that annotations are in the new jakarta namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,9 +135,15 @@
 
         <!-- Since java 11 JRE, this is needed at runtime (not in JRE anymore) -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.4.0-b180830.0359</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.5</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -376,7 +382,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>2.5.0</version>
+                <version>3.1.0</version>
                 <executions>
 
                     <!-- UNIPROT KB -->

--- a/src/main/resources/jaxb-bindings/efamily.xjb
+++ b/src/main/resources/jaxb-bindings/efamily.xjb
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <jaxb:bindings xmlns="http://java.sun.com/xml/ns/jaxws"
-          xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+          xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
           xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-          version="2.1">
+          version="3.0">
 
     <jaxb:globalBindings localScoping="toplevel">
         <jaxb:javaType name="java.util.Date" xmlType="xsd:date"/>

--- a/src/main/resources/jaxb-bindings/uniprot.xjb
+++ b/src/main/resources/jaxb-bindings/uniprot.xjb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<jaxb:bindings version="2.1"
-              xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+<jaxb:bindings version="3.0"
+              xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
               xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
               xmlns:xs="http://www.w3.org/2001/XMLSchema">
 


### PR DESCRIPTION
The effect is that the output classes change their annotations like this:

Before:
```
import javax.xml.bind.annotation.XmlRootElement
```
After:
```
import jakarta.xml.bind.annotation.XmlRootElement
```
This in turn seems to solve the problem I was seeing with rcsb-redwood build when upgrading to jakarta.xml.bind-api 4 (see https://github.com/rcsb/rcsb-redwood/pull/132#issuecomment-2030827231)

When building I see a warning about dtd for mesh, but the mesh classes seem to be built fine.